### PR TITLE
gulp-dep は再帰的な削除ができる

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,5 +47,5 @@ gulp.task('reload', function() {
 });
 
 gulp.task('clean:dist', function() {
-  return del(paths.dist + '**/*');
+  return del(paths.dist);
 });


### PR DESCRIPTION
`gulp-dep` は再帰的に削除できるので、明示的にファイルを指定しなくてもよいかと。
